### PR TITLE
Avoid positional boolean parameters

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class DemoState extends State<Demo> {
     super.dispose();
   }
 
-  bool myInterceptor(bool stopDefaultButtonEvent, RouteInfo info) {
+  bool myInterceptor(RouteInfo info, {required bool stopDefaultButtonEvent}) {
     print("BACK BUTTON!"); // Do some stuff.
     return true;
   }

--- a/example/lib/main_complex_example.dart
+++ b/example/lib/main_complex_example.dart
@@ -69,7 +69,8 @@ class Home extends StatelessWidget {
     );
   }
 
-  void openNewScreen(BuildContext context) => Navigator.pushNamed(context, RoutePaths.newScreen);
+  void openNewScreen(BuildContext context) =>
+      Navigator.pushNamed(context, RoutePaths.newScreen);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -143,7 +144,8 @@ class _ContainerWithInterceptorState extends State<ContainerWithInterceptor> {
   void initState() {
     super.initState();
     ifPop = false;
-    BackButtonInterceptor.add(myInterceptor, name: widget.name, context: context);
+    BackButtonInterceptor.add(myInterceptor,
+        name: widget.name, context: context);
   }
 
   @override
@@ -161,7 +163,7 @@ class _ContainerWithInterceptorState extends State<ContainerWithInterceptor> {
     );
   }
 
-  bool myInterceptor(bool stopDefaultButtonEvent, RouteInfo info) {
+  bool myInterceptor(RouteInfo info, {required bool stopDefaultButtonEvent}) {
     if (stopDefaultButtonEvent) return false;
 
     // If a dialog (or any other route) is open, don't run the interceptor.

--- a/example/lib/main_complex_example_routes_not_named.dart
+++ b/example/lib/main_complex_example_routes_not_named.dart
@@ -112,7 +112,7 @@ class NewScreen extends StatelessWidget {
             ),
             RaisedButton(
               onPressed: () => _openDialog(context),
-              child: const  Text('Open Dialog'),
+              child: const Text('Open Dialog'),
             ),
           ],
         ),
@@ -154,7 +154,8 @@ class _ContainerWithInterceptorState extends State<ContainerWithInterceptor> {
   void initState() {
     super.initState();
     ifPop = false;
-    BackButtonInterceptor.add(myInterceptor, name: widget.name, context: context);
+    BackButtonInterceptor.add(myInterceptor,
+        name: widget.name, context: context);
   }
 
   @override
@@ -172,7 +173,7 @@ class _ContainerWithInterceptorState extends State<ContainerWithInterceptor> {
     );
   }
 
-  bool myInterceptor(bool stopDefaultButtonEvent, RouteInfo info) {
+  bool myInterceptor(RouteInfo info, {required bool stopDefaultButtonEvent}) {
     if (stopDefaultButtonEvent) return false;
 
     // If a dialog (or any other route) is open, don't run the interceptor.

--- a/lib/src/back_button_interceptor.dart
+++ b/lib/src/back_button_interceptor.dart
@@ -25,10 +25,11 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
     Future.delayed(const Duration(), () => throw error);
   }
 
-  static Future<void> Function() handlePopRouteFunction = WidgetsBinding.instance!.handlePopRoute;
+  static Future<void> Function() handlePopRouteFunction =
+      WidgetsBinding.instance!.handlePopRoute;
 
-  static Future<void> Function(String?) handlePushRouteFunction =
-      WidgetsBinding.instance!.handlePushRoute as Future<void> Function(String?);
+  static Future<void> Function(String?) handlePushRouteFunction = WidgetsBinding
+      .instance!.handlePushRoute as Future<void> Function(String?);
 
   /// Sets a function to be called when the back button is tapped.
   /// This function may perform some useful work, and then, if it returns true,
@@ -64,8 +65,8 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
 
   /// Removes the function.
   static void remove(InterceptorFunction interceptorFunction) {
-    _interceptors
-        .removeWhere((interceptor) => interceptor.interceptionFunction == interceptorFunction);
+    _interceptors.removeWhere((interceptor) =>
+        interceptor.interceptionFunction == interceptorFunction);
   }
 
   /// Removes the function by name.
@@ -94,7 +95,8 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
   static String? getCurrentNavigatorRouteName(BuildContext context) =>
       getCurrentNavigatorRoute(context)!.settings.name;
 
-  static Future<dynamic> _handleNavigationInvocation(MethodCall methodCall) async {
+  static Future<dynamic> _handleNavigationInvocation(
+      MethodCall methodCall) async {
     // POP.
     if (methodCall.method == 'popRoute')
       return popRoute();
@@ -136,8 +138,8 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
 
         if (!interceptor.ifNotYetIntercepted || !stopDefaultButtonEvent) {
           result = interceptor.interceptionFunction(
-            stopDefaultButtonEvent,
             RouteInfo(routeWhenAdded: interceptor.routeWhenAdded),
+            stopDefaultButtonEvent: stopDefaultButtonEvent,
           );
 
           results.results.add(InterceptorResult(interceptor.name, result));
@@ -157,7 +159,8 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
     }
   }
 
-  static Future<void> _pushRoute(dynamic arguments) => handlePushRouteFunction(arguments as String?);
+  static Future<void> _pushRoute(dynamic arguments) =>
+      handlePushRouteFunction(arguments as String?);
 
   /// Describes all interceptors, with their names and z-indexes.
   /// This may help you debug your interceptors, by printing them
@@ -166,7 +169,8 @@ abstract class BackButtonInterceptor implements WidgetsBinding {
   static String describe() => _interceptors.join("\n");
 }
 
-typedef InterceptorFunction = bool Function(bool stopDefaultButtonEvent, RouteInfo routeInfo);
+typedef InterceptorFunction = bool Function(RouteInfo routeInfo,
+    {required bool stopDefaultButtonEvent});
 
 class RouteInfo {
   /// The current route when the interceptor was added


### PR DESCRIPTION
This is best practices from the [official documentation](https://dart-lang.github.io/linter/lints/avoid_positional_boolean_parameters.html).

AVOID positional boolean parameters.

Positional boolean parameters are a bad practice because they are very ambiguous. Using named boolean parameters is much more readable because it inherently describes what the boolean value represents.